### PR TITLE
Automatisk justering av antall avganger som vises i kompakt visning

### DIFF
--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -47,6 +47,8 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
         IconColorType.CONTRAST,
     )
 
+    console.log(groupedDepartures)
+
     useEffect(() => {
         if (settings) {
             setIconColorType(getIconColorType(settings.theme))
@@ -57,7 +59,7 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
         <Tile title={name} icons={headerIcons}>
             {routes.map((route) => {
                 const subType = groupedDepartures[route][0].subType
-                const routeData = groupedDepartures[route].slice(0, 3)
+                const routeData = groupedDepartures[route].slice(0, 5)
                 const routeType = routeData[0].type
                 const icon = getIcon(routeType, iconColorType, subType)
 

--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -37,17 +37,28 @@ function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
         .filter(isNotNullOrUndefined)
 }
 
-const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
+const DepartureTile = ({
+    stopPlaceWithDepartures,
+    numberOfCols,
+}: Props): JSX.Element => {
     const { departures, name } = stopPlaceWithDepartures
     const groupedDepartures = groupBy<LineData>(departures, 'route')
     const headerIcons = getTransportHeaderIcons(departures)
     const routes = Object.keys(groupedDepartures)
+    const cols = numberOfCols
     const [settings] = useSettingsContext()
     const [iconColorType, setIconColorType] = useState<IconColorType>(
         IconColorType.CONTRAST,
     )
 
-    console.log(groupedDepartures)
+    function calculateNumbOfDepatures(numberOfDepartures: LineData[]) {
+        if (cols === 4) {
+            return numberOfDepartures.slice(0, 4)
+        } else if (cols >= 5) {
+            return numberOfDepartures.slice(0, 2)
+        }
+        return numberOfDepartures
+    }
 
     useEffect(() => {
         if (settings) {
@@ -59,7 +70,9 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
         <Tile title={name} icons={headerIcons}>
             {routes.map((route) => {
                 const subType = groupedDepartures[route][0].subType
-                const routeData = groupedDepartures[route].slice(0, 5)
+                const routeData = calculateNumbOfDepatures(
+                    groupedDepartures[route],
+                )
                 const routeType = routeData[0].type
                 const icon = getIcon(routeType, iconColorType, subType)
 
@@ -78,6 +91,7 @@ const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
 
 interface Props {
     stopPlaceWithDepartures: StopPlaceWithDepartures
+    numberOfCols: number
 }
 
 export default DepartureTile

--- a/src/dashboards/Compact/components/TileRow/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/styles.scss
@@ -30,10 +30,10 @@
 
     &__sublabels {
         display: grid;
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(5, 1fr);
         font-size: 1.25rem;
         justify-content: space-between;
-        max-width: 20rem;
+        max-width: 30rem;
     }
 
     &__sublabel {

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -105,6 +105,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                             <DepartureTile
                                 key={index}
                                 stopPlaceWithDepartures={stop}
+                                numberOfCols={cols.lg}
                             />
                         </div>
                     ))}

--- a/src/logic/useStopPlacesWithDepartures.ts
+++ b/src/logic/useStopPlacesWithDepartures.ts
@@ -42,7 +42,7 @@ async function fetchStopPlaceDepartures(
         {
             includeNonBoarding: false,
             limit: 200,
-            limitPerLine: 3,
+            limitPerLine: 5,
         },
     )
 


### PR DESCRIPTION
Viser nå fem avganger på tre kort, fire på to kort og to på fem eller flere kort. Også endret slik at det hentes fem avganger fra backend i stedet for tre som det var tidligere.
![image](https://user-images.githubusercontent.com/22595827/93750630-12905280-fbfc-11ea-8218-2a880e8b2df7.png)
![image](https://user-images.githubusercontent.com/22595827/93750660-1e7c1480-fbfc-11ea-80cd-4a2c0824fa3f.png)
![image](https://user-images.githubusercontent.com/22595827/93750724-3bb0e300-fbfc-11ea-9e15-49f09599a292.png)


