### PR TITLE
Add width dependent number of departures in compact view

### DIFF
--- a/src/dashboards/Compact/DepartureTile/index.tsx
+++ b/src/dashboards/Compact/DepartureTile/index.tsx
@@ -37,30 +37,15 @@ function getTransportHeaderIcons(departures: LineData[]): JSX.Element[] {
         .filter(isNotNullOrUndefined)
 }
 
-const DepartureTile = ({
-    stopPlaceWithDepartures,
-    numberOfCols,
-}: Props): JSX.Element => {
+const DepartureTile = ({ stopPlaceWithDepartures }: Props): JSX.Element => {
     const { departures, name } = stopPlaceWithDepartures
     const groupedDepartures = groupBy<LineData>(departures, 'route')
     const headerIcons = getTransportHeaderIcons(departures)
     const routes = Object.keys(groupedDepartures)
-    const cols = numberOfCols
     const [settings] = useSettingsContext()
     const [iconColorType, setIconColorType] = useState<IconColorType>(
         IconColorType.CONTRAST,
     )
-
-    const calculateNumbOfDepatures = (
-        numberOfDepartures: LineData[],
-    ): LineData[] => {
-        if (cols === 4) {
-            return numberOfDepartures.slice(0, 4)
-        } else if (cols >= 5) {
-            return numberOfDepartures.slice(0, 3)
-        }
-        return numberOfDepartures
-    }
 
     useEffect(() => {
         if (settings) {
@@ -72,9 +57,7 @@ const DepartureTile = ({
         <Tile title={name} icons={headerIcons}>
             {routes.map((route) => {
                 const subType = groupedDepartures[route][0].subType
-                const routeData = calculateNumbOfDepatures(
-                    groupedDepartures[route],
-                )
+                const routeData = groupedDepartures[route]
                 const routeType = routeData[0].type
                 const icon = getIcon(routeType, iconColorType, subType)
 
@@ -93,7 +76,6 @@ const DepartureTile = ({
 
 interface Props {
     stopPlaceWithDepartures: StopPlaceWithDepartures
-    numberOfCols: number
 }
 
 export default DepartureTile

--- a/src/dashboards/Compact/components/TileRow/styles.scss
+++ b/src/dashboards/Compact/components/TileRow/styles.scss
@@ -20,7 +20,7 @@
     &__icon {
         min-width: 2rem;
         margin-right: 1rem;
-        font-size: 2rem;
+        font-size: $font-sizes-extra-large4;
     }
 
     &__texts {
@@ -30,8 +30,10 @@
 
     &__sublabels {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(0.5rem, 1fr));
-        font-size: 1.25rem;
+        grid-template-columns: repeat(20, 1fr);
+        justify-content: space-between;
+        min-width: 130rem;
+        font-size: $font-sizes-extra-large;
     }
 
     &__sublabel {

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -48,7 +48,6 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
 
     let stopPlacesWithDepartures = useStopPlacesWithDepartures()
 
-    // Remove stop places without departures
     if (stopPlacesWithDepartures) {
         stopPlacesWithDepartures = stopPlacesWithDepartures.filter(
             ({ departures }) => departures.length > 0,
@@ -113,7 +112,6 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                             <DepartureTile
                                 key={index}
                                 stopPlaceWithDepartures={stop}
-                                numberOfCols={cols.lg}
                             />
                         </div>
                     ))}

--- a/src/dashboards/Compact/styles.scss
+++ b/src/dashboards/Compact/styles.scss
@@ -47,6 +47,19 @@
         z-index: 1;
     }
 
+    .react-grid-item:not(#scooter)::before {
+        content: '';
+        position: absolute;
+        width: 2rem;
+        height: 80%;
+        right: 0;
+        bottom: 0;
+        background-color: var(--tavla-box-background-color);
+        mask-image: linear-gradient(to right, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 70%, rgba(0, 0, 0, 1) 100%);
+        //-webkit-mask-image: -webkit-linear-gradient(to right, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 70%, rgba(0, 0, 0, 1) 100%);
+        z-index: 1;
+    }
+
     .react-grid-item.cssTransforms {
         transition-property: transform;
     }

--- a/src/logic/useStopPlacesWithDepartures.ts
+++ b/src/logic/useStopPlacesWithDepartures.ts
@@ -32,7 +32,7 @@ async function fetchStopPlaceDepartures(
         {
             includeNonBoarding: false,
             limit: 200,
-            limitPerLine: 5,
+            limitPerLine: 20,
         },
     )
     return { sortedStops, departures }


### PR DESCRIPTION
Also adds a fade to the right side of the tiles that is reminiscent of the fade at bottom of the cards.
![image](https://user-images.githubusercontent.com/22595827/95182540-0fcd5a00-07c5-11eb-9da6-390599c179ba.png)
