### PR TITLE
Added bike rental stations to the maps in admin panel and scootertile

### DIFF
--- a/src/containers/Admin/EditTab/ZoomEditor/index.tsx
+++ b/src/containers/Admin/EditTab/ZoomEditor/index.tsx
@@ -7,9 +7,10 @@ import './styles.scss'
 import { Label } from '@entur/typography'
 import { DEFAULT_ZOOM } from '../../../../constants'
 import { useSettingsContext } from '../../../../settings'
-import { Scooter } from '@entur/sdk'
+import { Scooter, BikeRentalStation } from '@entur/sdk'
 import ScooterOperatorLogo from '../../../../assets/icons/scooterOperatorLogo'
 import PositionPin from '../../../../assets/icons/positionPin'
+import BicycleTag from '../../../../dashboards/Map/BicycleTag'
 
 function ZoomEditor(props: Props): JSX.Element {
     const [settings, { setZoom }] = useSettingsContext()
@@ -67,6 +68,18 @@ function ZoomEditor(props: Props): JSX.Element {
                           </Marker>
                       ))
                     : []}
+                {props.bikeRentalStations?.map((station) => (
+                    <Marker
+                        key={station.id}
+                        latitude={station.latitude}
+                        longitude={station.longitude}
+                    >
+                        <BicycleTag
+                            bikes={station.bikesAvailable ?? 0}
+                            spaces={station.spacesAvailable ?? 0}
+                        />
+                    </Marker>
+                ))}
                 <Marker
                     latitude={viewport.latitude || 0}
                     longitude={viewport.longitude || 0}
@@ -82,6 +95,7 @@ interface Props {
     zoom: number
     onZoomUpdated: (newZoom: number) => void
     scooters: Scooter[] | null
+    bikeRentalStations: BikeRentalStation[] | null
 }
 
 export default memo<Props>(ZoomEditor)

--- a/src/containers/Admin/EditTab/index.tsx
+++ b/src/containers/Admin/EditTab/index.tsx
@@ -187,6 +187,7 @@ const EditTab = (): JSX.Element => {
                         zoom={zoom}
                         onZoomUpdated={setZoom}
                         scooters={scooters}
+                        bikeRentalStations={stations}
                     />
                 </GridItem>
             </GridContainer>

--- a/src/dashboards/Compact/ScooterTile/index.tsx
+++ b/src/dashboards/Compact/ScooterTile/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import ReactMapGL, { Marker } from 'react-map-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
 
-import { Scooter } from '@entur/sdk'
+import { Scooter, BikeRentalStation } from '@entur/sdk'
 import { colors } from '@entur/tokens'
 import { ScooterIcon } from '@entur/icons'
 import { useSettingsContext } from '../../../settings'
@@ -13,8 +13,9 @@ import PositionPin from '../../../assets/icons/positionPin'
 
 import './styles.scss'
 import { DEFAULT_ZOOM } from '../../../constants'
+import BicycleTag from '../../Map/BicycleTag'
 
-function ScooterTile({ scooters }: Props): JSX.Element {
+function ScooterTile({ scooters, bikeRentalStations }: Props): JSX.Element {
     const [settings] = useSettingsContext()
     const [viewport] = useState({
         latitude: settings?.coordinates?.latitude,
@@ -46,6 +47,18 @@ function ScooterTile({ scooters }: Props): JSX.Element {
                         <ScooterOperatorLogo logo={sctr.operator} size="24px" />
                     </Marker>
                 ))}
+                {bikeRentalStations?.map((station) => (
+                    <Marker
+                        key={station.id}
+                        latitude={station.latitude}
+                        longitude={station.longitude}
+                    >
+                        <BicycleTag
+                            bikes={station.bikesAvailable ?? 0}
+                            spaces={station.spacesAvailable ?? 0}
+                        />
+                    </Marker>
+                ))}
                 <Marker
                     latitude={viewport.latitude || 0}
                     longitude={viewport.longitude || 0}
@@ -59,6 +72,7 @@ function ScooterTile({ scooters }: Props): JSX.Element {
 
 interface Props {
     scooters: Scooter[]
+    bikeRentalStations: BikeRentalStation[] | null
 }
 
 export default ScooterTile

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -141,7 +141,10 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                             )}
                         >
                             <ResizeHandle size="32" className="resizeHandle" />
-                            <ScooterTile scooters={scooters} />
+                            <ScooterTile
+                                scooters={scooters}
+                                bikeRentalStations={bikeRentalStations}
+                            />
                         </div>
                     ) : (
                         []


### PR DESCRIPTION
La til bysykler i kartene i admin-panelet og i kompakt-visning. `<Marker>` for bysykkel hentes fra mapview, som er noe uheldig, burde kanskje generaliseres og hentes et annet sted? Syns uansett det ble mye clutter med sparkesykler og bysykler, men er interessert i hva dere syns

![image](https://user-images.githubusercontent.com/14358485/95574994-37732b00-0a2e-11eb-9f87-b8869cc78e4c.png)
![image](https://user-images.githubusercontent.com/14358485/95575040-52459f80-0a2e-11eb-8297-22fb9e8fe008.png)
