### PR TITLE
Change ResizeHandle's size prop to number rather than string

### DIFF
--- a/src/assets/icons/ResizeHandle.tsx
+++ b/src/assets/icons/ResizeHandle.tsx
@@ -61,7 +61,7 @@ function ResizeHandle({ className, size, variant }: Props): JSX.Element | null {
 
 interface Props {
     className?: string
-    size?: string
+    size?: number
     variant?: 'light' | 'dark'
 }
 

--- a/src/dashboards/Compact/index.tsx
+++ b/src/dashboards/Compact/index.tsx
@@ -115,7 +115,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                             data-grid={getDataGrid(index, maxWidthCols)}
                         >
                             <ResizeHandle
-                                size="32"
+                                size={32}
                                 className="resizeHandle"
                                 variant="light"
                             />
@@ -134,7 +134,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                             )}
                         >
                             <ResizeHandle
-                                size="32"
+                                size={32}
                                 className="resizeHandle"
                                 variant="light"
                             />
@@ -153,7 +153,7 @@ const EnturDashboard = ({ history }: Props): JSX.Element => {
                             )}
                         >
                             <ResizeHandle
-                                size="32"
+                                size={32}
                                 className="resizeHandle"
                                 variant="dark"
                             />


### PR DESCRIPTION
This was commented in the PR that introduced ResizeHandle, and I was sure it was already fixed 🤔 Better late than never though!